### PR TITLE
Make message display robust to null image urls

### DIFF
--- a/android/app/src/main/java/com/google/firebase/codelab/friendlychat/MainActivity.java
+++ b/android/app/src/main/java/com/google/firebase/codelab/friendlychat/MainActivity.java
@@ -198,7 +198,7 @@ public class MainActivity extends AppCompatActivity implements
                     viewHolder.messageTextView.setText(friendlyMessage.getText());
                     viewHolder.messageTextView.setVisibility(TextView.VISIBLE);
                     viewHolder.messageImageView.setVisibility(ImageView.GONE);
-                } else {
+                } else if (friendlyMessage.getImageUrl() != null) {
                     String imageUrl = friendlyMessage.getImageUrl();
                     if (imageUrl.startsWith("gs://")) {
                         StorageReference storageReference = FirebaseStorage.getInstance()


### PR DESCRIPTION
If the user had previously done the iOS codelab, some messages will not have imageURL fields.