### PR TITLE
Update build.grade - AAPT2 moved to Google's Maven repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
         mavenLocal()
         maven { url 'https://maven.fabric.io/public'  }
-        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -19,6 +19,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenLocal()
         maven { url 'https://maven.google.com'  }


### PR DESCRIPTION
Beginning with Android Studio 3.2, the source for AAPT2 (Android Asset Packaging Tool 2) is Google's Maven repository.

This change fixes gradle lint related errors.

Source:
https://developer.android.com/studio/releases/#aapt2_gmaven