### PR TITLE
Updated  to 21 to support  attribute

### DIFF
--- a/build-android-start/app/build.gradle
+++ b/build-android-start/app/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-database'
     implementation 'com.google.firebase:firebase-storage'
-    implementation 'com.google.firebase:firebase-auth'got
+    implementation 'com.google.firebase:firebase-auth'
 
     // Firebase UI
     implementation 'com.firebaseui:firebase-ui-database:3.3.1'

--- a/build-android-start/app/build.gradle
+++ b/build-android-start/app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "com.google.firebase.codelab.friendlychat"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
@@ -46,7 +46,7 @@ dependencies {
 
     implementation 'com.google.firebase:firebase-database'
     implementation 'com.google.firebase:firebase-storage'
-    implementation 'com.google.firebase:firebase-auth'
+    implementation 'com.google.firebase:firebase-auth'got
 
     // Firebase UI
     implementation 'com.firebaseui:firebase-ui-database:3.3.1'

--- a/build-android/app/build.gradle
+++ b/build-android/app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "com.google.firebase.codelab.friendlychat"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Fixes #73 

I believe this is was omitted during pervious updates, As [grow-friendly-app](https://github.com/firebase/friendlychat-android/blob/master/grow-android-start/app/build.gradle#L10) has `minSdkVersion` as 21.
