### PR TITLE
To override transitive dependencies to `28.0.0` version

### DIFF
--- a/build-android-start/app/build.gradle
+++ b/build-android-start/app/build.gradle
@@ -28,7 +28,7 @@ android {
 
 dependencies {
     configurations.all {
-        resolutionStrategy.force 'com.android.support:design:27.1.1'
+        resolutionStrategy.force 'com.android.support:design:28.0.0'
     }
 
     testImplementation 'junit:junit:4.12'
@@ -37,6 +37,8 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.7.1'
     implementation 'de.hdodenhof:circleimageview:1.3.0'
     implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:support-media-compat:28.0.0'
 
     // Google
     implementation 'com.google.android.gms:play-services-auth:16.0.1'

--- a/build-android/app/build.gradle
+++ b/build-android/app/build.gradle
@@ -28,7 +28,7 @@ android {
 
 dependencies {
     configurations.all {
-        resolutionStrategy.force 'com.android.support:design:27.1.1'
+        resolutionStrategy.force 'com.android.support:design:28.0.0'
     }
 
     testImplementation 'junit:junit:4.12'
@@ -37,6 +37,8 @@ dependencies {
     implementation 'com.github.bumptech.glide:glide:4.7.1'
     implementation 'de.hdodenhof:circleimageview:1.3.0'
     implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:support-media-compat:28.0.0'
 
     // Google
     implementation 'com.google.android.gms:play-services-auth:16.0.1'


### PR DESCRIPTION
Fixes #75

This change updates `com.android.support:design` to `28.0.0` and introduces;
```
implementation 'com.android.support:support-v4:28.0.0'
implementation 'com.android.support:support-media-compat:28.0.0
```